### PR TITLE
Feature, adding time lock example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ deploy-test-stakable-base-contract:
 	hardhat add-demo-projects
 	make test-contract CONTRACT=$(CONTRACT)
 
+# Deploy timelock example contract and run tests
+deploy-test-timelock:
+	make deploy-test CONTRACT=TimelockExample

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ This is a one step command to get everything started for you.
 make deploy-test-stakable-base-contract
 ```
 
+## Other contracts with tests, to use as inspiration
+
+### Timelock example
+
+As part of our staking contract We are aiming to add time lock capabilities for modifying longtime locks for the ability for users to undertake their value from a given project. This is a temporary measure for the basis of the hackathon.
+
+```
+make deploy-test-timelock
+```
 
 ## Notes
 

--- a/contracts/TimelockExample.sol
+++ b/contracts/TimelockExample.sol
@@ -1,0 +1,49 @@
+/// @author Matt Smithies (DOVU Global Limited)
+
+/// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Import Hedera-specific HTS interop contracts
+import "./libraries/hashgraph/HederaTokenService.sol";
+import "./libraries/hashgraph/HederaResponseCodes.sol";
+
+/**
+* What we are trying to achieve here is to create a basic contract with a time lock mechanism that allows us to modify the time lock as well
+*/
+contract TimelockExample is HederaTokenService, Ownable {
+
+    uint timelock;
+
+    bool lockTimeChange = true;
+
+    modifier canChangeTime() {
+        require(!lockTimeChange);
+        _;
+    }
+
+    constructor() {
+        timelock = block.timestamp;
+    }
+
+    function isTimelockEnabled() public view onlyOwner returns (bool) {
+        return lockTimeChange || timelock > block.timestamp;
+    }
+
+    function addDays(uint amount_) public canChangeTime {
+        timelock += amount_ * 1 days;
+    }
+
+    function removeDays(uint amount_) public canChangeTime {
+        timelock -= amount_ * 1 days;
+    }
+
+    function updateTimeLock(bool lockTimeChange_) public onlyOwner {
+        lockTimeChange = lockTimeChange_;
+    }
+
+    function getBlockTimeStamp() public view returns (uint) {
+        return block.timestamp;
+    }
+}

--- a/test/timelockexample-contract.js
+++ b/test/timelockexample-contract.js
@@ -1,0 +1,130 @@
+const { expect } = require("chai");
+
+const {
+  Network,
+  Config,
+  Hashgraph,
+  SDK: {
+    ReceiptStatusError,
+    ContractFunctionParameters,
+    AccountId
+  },
+} = require("hashgraph-support")
+
+describe("Testing a contract", function () {
+
+  const destinationNetwork = Config.network
+  const client = Network.getNodeNetworkClient(destinationNetwork)
+  const hashgraph = Hashgraph(client);
+
+  const contractId = process.env.TIMELOCKEXAMPLE_CONTRACT_ID;
+
+  it("A contract will run a test", async () => {
+
+    // Will run if a contract is Ownable
+    const response = await hashgraph.contract.query({
+      contractId: contractId,
+      method: "owner",
+    })
+
+    const accountId = AccountId.fromSolidityAddress(response.getAddress(0))
+
+    expect(accountId.toString()).to.equal(process.env.HEDERA_ACCOUNT_ID);
+  })
+
+  it("A contract ensure that the timelock is on (default behaviour)", async () => {
+
+    const response = await hashgraph.contract.query({
+      contractId: contractId,
+      method: "isTimelockEnabled",
+    })
+
+    expect(response.getBool(0)).to.true;
+  })
+
+
+  it("Add days to time lock (fails)", async () => {
+    try {
+      const response = await hashgraph.contract.call({
+        contractId: contractId,
+        method: "addDays",
+        params: new ContractFunctionParameters()
+          .addUint256(1)
+      })
+
+      expect(response).to.be.true;
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(ReceiptStatusError)
+    }
+  })
+
+
+  it("Update timelock to accept day modification", async () => {
+    const response = await hashgraph.contract.call({
+      contractId: contractId,
+      method: "updateTimeLock",
+      params: new ContractFunctionParameters()
+        .addBool(false)
+    })
+
+    expect(response).to.be.true;
+  })
+
+  it("A contract ensure that the timelock is on", async () => {
+
+    const response = await hashgraph.contract.query({
+      contractId: contractId,
+      method: "isTimelockEnabled",
+    })
+
+    expect(response.getBool(0)).to.false
+  })
+
+  it("remove days from time lock", async () => {
+
+    const response = await hashgraph.contract.call({
+      contractId: contractId,
+      method: "removeDays",
+      params: new ContractFunctionParameters()
+        .addUint256(1)
+    })
+
+    expect(response).to.be.true;
+  })
+
+  it("A contract ensure that the timelock is off", async () => {
+
+    const response = await hashgraph.contract.query({
+      contractId: contractId,
+      method: "isTimelockEnabled",
+    })
+
+    expect(response.getBool(0)).to.false;
+  })
+
+  it("Revert state for ensuring contract is timelocked", async () => {
+    const response = await hashgraph.contract.call({
+      contractId: contractId,
+      method: "updateTimeLock",
+      params: new ContractFunctionParameters()
+        .addBool(true)
+    })
+
+    expect(response).to.be.true;
+  })
+
+  it("Get contract current block timestamp", async () => {
+
+    const response = await hashgraph.contract.query({
+      contractId: contractId,
+      method: "getBlockTimeStamp",
+    })
+
+    const timestamp = response.getUint256(0).toNumber()
+
+    console.log(timestamp)
+
+    // lol
+    expect(timestamp).to.gte(0);
+  })
+});


### PR DESCRIPTION
## Overview

These files add a timelock contract example to the codebase, you can use this contract as a basis for adding and modifying time locks for a given user with a stake.

Of course, in production, we wouldn't use the functionality to modify timelocks on the fly.