### PR TITLE
Road to tooling template V1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ deploy-test:
 	make deploy CONTRACT=$(CONTRACT)
 	make test-contract CONTRACT=$(CONTRACT)
 
-## This is the solidity contract name
+## This is the solidity contract name (example of custom commands)
 CONTRACT = "StakableProject"
 
 ## Simply a utility to get the contract into a state that is completely tested and employed given a custom environment/owner, with demo projects

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is some simple tooling that you can utilise to start to work with Hedera Sm
 - Example tests of simple smart contracts.
 - Basic scaffold of interacting and creating contracts for Hedera.
 - Example flow for reducing feedback loop for deployment/testing contracts
+- Checks for valid contract ids in ENV before attempting tests  
 
 Generally for users that are new to smart contracts having to deal with loop of compiling contracts then injecting them into the methods in order for them to be deployed onto the network can be a bit mysterious and challenging.
 

--- a/stub/example-test-contract.js
+++ b/stub/example-test-contract.js
@@ -18,6 +18,10 @@ describe("Testing a contract", function () {
 
   const contractId = process.env.REPLACEME_CONTRACT_ID;
 
+  if (!contractId) {
+    throw Error("REPLACEME_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+
   it("A contract will run a test", async () => {
 
     // Will run if a contract is Ownable

--- a/test/hellostruct-contract.js
+++ b/test/hellostruct-contract.js
@@ -18,6 +18,10 @@ describe("Testing HelloStruct Contract", function () {
 
   const contractId = process.env.HELLOSTRUCT_CONTRACT_ID;
 
+  if (!contractId) {
+    throw Error("HELLOSTRUCT_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+
   it("A contract will run a test, ownable", async () => {
 
     const response = await hashgraph.contract.query({
@@ -59,5 +63,17 @@ describe("Testing HelloStruct Contract", function () {
     })
 
     expect(response.getString(0)).to.equal("Hello Again");
+  })
+
+  it("Contract will revert contract state value", async () => {
+
+    const response = await hashgraph.contract.call({
+      contractId: contractId,
+      method: "update",
+      params: new ContractFunctionParameters()
+        .addString('hello world')
+    })
+
+    expect(response).to.be.true;
   })
 });

--- a/test/helloworld-contract.js
+++ b/test/helloworld-contract.js
@@ -18,6 +18,10 @@ describe("Testing Helloworld Ownable contracts", function () {
 
   const contractId = process.env.HELLOWORLD_CONTRACT_ID;
 
+  if (!contractId) {
+    throw Error("HELLOWORLD_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+
   it("A contract can get owner address", async () => {
 
     const response = await hashgraph.contract.query({

--- a/test/hts-contract.js
+++ b/test/hts-contract.js
@@ -17,6 +17,10 @@ describe("A contract can associate and be sent tokens", function () {
 
   const contractId = process.env.HTS_CONTRACT_ID;
 
+  if (!contractId) {
+    throw Error("HTS_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+
   it("A contract can get the token id", async () => {
 
     const response = await hashgraph.contract.query({

--- a/test/stakableproject-contract.js
+++ b/test/stakableproject-contract.js
@@ -22,6 +22,11 @@ describe("Testing a basic contract for stakable projects", function () {
   const hashgraph = Hashgraph(client);
 
   const contractId = process.env.STAKABLEPROJECT_CONTRACT_ID;
+
+  if (!contractId) {
+    throw Error("STAKABLEPROJECT_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+  
   const account_id = '0.0.1' + Math.floor(Math.random() * 100000)
 
   const baseVerifiedCarbon = 5;

--- a/test/timelockexample-contract.js
+++ b/test/timelockexample-contract.js
@@ -19,6 +19,10 @@ describe("Testing a contract", function () {
 
   const contractId = process.env.TIMELOCKEXAMPLE_CONTRACT_ID;
 
+  if (!contractId) {
+    throw Error("TIMELOCKEXAMPLE_CONTRACT_ID: NOT FOUND IN ENV, deploy with 'make deploy-test CONTRACT=\"ContractName\"' to generate in ENV")
+  }
+
   it("A contract will run a test", async () => {
 
     // Will run if a contract is Ownable


### PR DESCRIPTION
## Motivation

As a developer, if I run a test, I would like to check that I can attempt to hit a valid contract before continuing.

## Overview

These items at the final checks for the environment validation inside of the JS tests.

- The js test stub will transform with the name of the contract id, as before but with the ENV contract id check
- The current tests have been updated.

Naturally, more documentation is warranted. @jonwood2 will be tasked with this (later)

